### PR TITLE
peregrine: added support for two codes input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,10 @@ build/
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
+
+# Eclipse project files
+.pydevproject
+.project
+.cproject
+.settings/
+

--- a/peregrine/analysis/samples.py
+++ b/peregrine/analysis/samples.py
@@ -59,7 +59,7 @@ def hist(samples, ax=None, value_range=None, bin_width=1.0, max_len=ANALYSIS_MAX
 
   """
   if max_len is not None and len(samples) > max_len:
-    logger.debug( "Truncating to %d samples." % max_len)
+    logger.debug("Truncating to %d samples." % max_len)
     samples = samples[:max_len]
 
   if ax is None:
@@ -72,8 +72,8 @@ def hist(samples, ax=None, value_range=None, bin_width=1.0, max_len=ANALYSIS_MAX
     max_val = np.max(samples)
     min_val = np.min(samples)
 
-  n_bins =  1 + np.round(float(max_val) - float(min_val) / bin_width)
-  bins = np.linspace(min_val-bin_width/2.0, max_val+bin_width/2.0, n_bins+1)
+  n_bins = 1 + np.round(float(max_val) - float(min_val) / bin_width)
+  bins = np.linspace(min_val - bin_width / 2.0, max_val + bin_width / 2.0, n_bins + 1)
 
   ticks = np.linspace(min_val, max_val, n_bins)
 
@@ -83,11 +83,11 @@ def hist(samples, ax=None, value_range=None, bin_width=1.0, max_len=ANALYSIS_MAX
   ax.set_xlabel('Sample value')
   if len(ticks) < 22:
     ax.set_xticks(ticks)
-  ax.set_xbound(min_val-bin_width, max_val+bin_width)
+  ax.set_xbound(min_val - bin_width, max_val + bin_width)
   ax.set_ylabel('Count')
   y_min, y_max = ax.get_ybound()
-  ax.set_ybound(0, y_max*1.1)
-  ax.ticklabel_format(style='sci', scilimits=(0,0), axis='y')
+  ax.set_ybound(0, y_max * 1.1)
+  ax.ticklabel_format(style='sci', scilimits=(0, 0), axis='y')
 
   return ax
 
@@ -118,7 +118,7 @@ def psd(samples, sampling_freq=None, ax=None, max_len=ANALYSIS_MAX_LEN):
 
   """
   if max_len is not None and len(samples) > max_len:
-    logger.debug( "Truncating to %d samples." % max_len)
+    logger.debug("Truncating to %d samples." % max_len)
     samples = samples[:max_len]
 
   if ax is None:
@@ -132,7 +132,7 @@ def psd(samples, sampling_freq=None, ax=None, max_len=ANALYSIS_MAX_LEN):
     ax.set_ylabel('Power Spectral Density ($f_s \cdot \mathrm{Hz}^{-1}$)')
     sampling_freq = 1.0
   else:
-    ax.ticklabel_format(style='sci', scilimits=(0,0), axis='x')
+    ax.ticklabel_format(style='sci', scilimits=(0, 0), axis='x')
     ax.set_xlabel('Frequency (Hz)')
     ax.set_ylabel('Power Spectral Density ($\mathrm{Hz}^{-1}$)')
 
@@ -143,7 +143,7 @@ def psd(samples, sampling_freq=None, ax=None, max_len=ANALYSIS_MAX_LEN):
                         noverlap=1024)
 
   ax.semilogy(freqs, Pxx, color='black')
-  ax.set_xbound(0, sampling_freq/2.0)
+  ax.set_xbound(0, sampling_freq / 2.0)
 
   return ax
 
@@ -172,8 +172,8 @@ def summary(samples, sampling_freq=None, max_len=ANALYSIS_MAX_LEN):
   ax1 = fig.add_subplot(121)
   ax2 = fig.add_subplot(122)
 
-  hist(samples, ax=ax1, max_len=max_len)
-  psd(samples, sampling_freq, ax=ax2, max_len=max_len)
+  hist(samples[0], ax=ax1, max_len=max_len)
+  psd(samples[0], sampling_freq, ax=ax2, max_len=max_len)
 
   fig.set_size_inches(10, 4, forward=True)
   fig.tight_layout()
@@ -193,7 +193,7 @@ def main():
                       + "'int8', '1bit', '1bitrev' or 'piksi' (default)")
   args = parser.parse_args()
 
-  samples = peregrine.samples.load_samples(args.file, args.num_samples, file_format = args.format)
+  samples = peregrine.samples.load_samples(args.file, args.num_samples, file_format=args.format)
   summary(samples)
 
   plt.show()

--- a/peregrine/run.py
+++ b/peregrine/run.py
@@ -64,10 +64,10 @@ def main():
       sys.exit(1)
   else:
     # Get 11ms of acquisition samples for fine frequency estimation
-    acq_samples = load_samples(args.file, 11*samplesPerCode,
+    acq_samples = load_samples(args.file, 11 * samplesPerCode,
                                settings.skipNumberOfBytes,
                                file_format=args.file_format)
-    acq = Acquisition(acq_samples)
+    acq = Acquisition(acq_samples[0])
     acq_results = acq.acquisition()
 
     print "Acquisition is over!"
@@ -101,10 +101,10 @@ def main():
       sys.exit(1)
   else:
     signal = load_samples(args.file,
-                          int(settings.samplingFreq*1e-3*(settings.msToProcess+22)),
+                          int(settings.samplingFreq * 1e-3 * (settings.msToProcess + 22)),
                           settings.skipNumberOfBytes,
                           file_format=args.file_format)
-    track_results = track(signal, acq_results, settings.msToProcess)
+    track_results = track(signal[0], acq_results, settings.msToProcess)
     try:
       with open(track_results_file, 'wb') as f:
         cPickle.dump(track_results, f, protocol=cPickle.HIGHEST_PROTOCOL)
@@ -127,7 +127,7 @@ def main():
         nav_results[0][2][0], nav_results[0][2][1], nav_results[0][2][2])
       with open(nav_results_file, 'wb') as f:
         cPickle.dump(nav_results, f, protocol=cPickle.HIGHEST_PROTOCOL)
-      print "and %d more are cPickled in '%s'." % (len(nav_results)-1, nav_results_file)
+      print "and %d more are cPickled in '%s'." % (len(nav_results) - 1, nav_results_file)
     else:
       print "No navigation results."
 

--- a/peregrine/samples.py
+++ b/peregrine/samples.py
@@ -42,8 +42,9 @@ def load_samples(filename, num_samples=-1, num_skip=0, file_format='piksi'):
 
   Returns
   -------
-  out : :class:`numpy.ndarray`, shape(`num_samples`,)
-    The sample data as a numpy array.
+  out : :class:`numpy.ndarray`, shape(bands, `num_samples`,)
+    The sample data as a two-dimensional numpy array. The first dimension
+    separates codes (bands).
 
   Raises
   ------
@@ -58,37 +59,38 @@ def load_samples(filename, num_samples=-1, num_skip=0, file_format='piksi'):
   if file_format == 'int8':
     with open(filename, 'rb') as f:
       f.seek(num_skip)
-      samples = np.fromfile(f, dtype=np.int8, count=num_samples)
+      samples = np.zeros((1, num_samples), dtype=np.int8)
+      samples[:] = np.fromfile(f, dtype=np.int8, count=num_samples)
   elif file_format == 'c8c8':
     # Interleaved complex samples from two receivers, i.e. first four bytes are
     # I0 Q0 I1 Q1
     s_file = np.memmap(filename, offset=num_skip, dtype=np.int8, mode='r')
     n_rx = 2
     if num_samples > 0:
-      s_file = s_file[:num_samples*2*n_rx]
-    samples = np.empty([n_rx, len(s_file)/(2 * n_rx)], dtype=np.complex64)
+      s_file = s_file[:num_samples * 2 * n_rx]
+    samples = np.empty([n_rx, len(s_file) / (2 * n_rx)], dtype=np.complex64)
     for rx in range(n_rx):
-      samples[rx] = s_file[2 * rx : : 2 * n_rx] + s_file[2*rx + 1 :: 2 * n_rx]*1j
+      samples[rx] = s_file[2 * rx : : 2 * n_rx] + s_file[2 * rx + 1 :: 2 * n_rx] * 1j
   elif file_format == 'c8c8_tayloe':
     # Interleaved complex samples from two receivers, i.e. first four bytes are
     # I0 Q0 I1 Q1.  Tayloe-upconverted to become purely real with fs=4fs0, fi=fs0
     s_file = np.memmap(filename, offset=num_skip, dtype=np.int8, mode='r')
     n_rx = 2
     if num_samples > 0:
-      s_file = s_file[:num_samples*2*n_rx]
-    samples = np.empty([n_rx, 4*len(s_file)/(2 * n_rx)], dtype=np.int8)
+      s_file = s_file[:num_samples * 2 * n_rx]
+    samples = np.empty([n_rx, 4 * len(s_file) / (2 * n_rx)], dtype=np.int8)
     for rx in range(n_rx):
-      samples[rx][0::4] =  s_file[2 * rx     : : 2 * n_rx]
+      samples[rx][0::4] = s_file[2 * rx     : : 2 * n_rx]
       samples[rx][1::4] = -s_file[2 * rx + 1 : : 2 * n_rx]
       samples[rx][2::4] = -s_file[2 * rx     : : 2 * n_rx]
-      samples[rx][3::4] =  s_file[2 * rx + 1 : : 2 * n_rx]
+      samples[rx][3::4] = s_file[2 * rx + 1 : : 2 * n_rx]
 
   elif file_format == 'piksinew':
     packed = np.memmap(filename, offset=num_skip, dtype=np.uint8, mode='r')
     if num_samples > 0:
       packed = packed[:num_samples]
-    samples = np.empty(len(packed), dtype=np.int8)
-    samples[:] = (packed >> 6) - 1
+    samples = np.empty((1, len(packed)), dtype=np.int8)
+    samples[0][:] = (packed >> 6) - 1
 
   elif file_format == 'piksi':
     """
@@ -105,7 +107,7 @@ def load_samples(filename, num_samples=-1, num_skip=0, file_format='piksi'):
     if num_samples > 0:
       num_skip_bytes = num_skip / 2
       num_skip_samples = num_skip % 2
-      num_bytes = num_samples/2 + 1
+      num_bytes = num_samples / 2 + 1
     else:
       # Read whole file
       num_skip_bytes = 0
@@ -122,17 +124,20 @@ def load_samples(filename, num_samples=-1, num_skip=0, file_format='piksi'):
     samples[::2] = (packed >> 5)
     samples[1::2] = (packed >> 2) & 7
     # Sign-magnitude to two's complement mapping
-    samples = (1-2*(samples>>2)) * (2*(samples&3)+1)
+    samples = (1 - 2 * (samples >> 2)) * (2 * (samples & 3) + 1)
 
     samples = samples[num_skip_samples:]
     if num_samples > 0:
       samples = samples[:num_samples]
+    tmp = np.ndarray((1, len(samples)), dtype=np.int8)
+    tmp[0][:] = samples
+    samples = tmp
 
   elif file_format == '1bit' or file_format == '1bitrev':
     if num_samples > 0:
       num_skip_bytes = num_skip / 8
       num_skip_samples = num_skip % 8
-      num_bytes = num_samples/8 + 1
+      num_bytes = num_samples / 8 + 1
     else:
       # Read whole file
       num_skip_bytes = 0
@@ -146,11 +151,28 @@ def load_samples(filename, num_samples=-1, num_skip=0, file_format='piksi'):
     samples *= 2
     samples -= 1
     if file_format == '1bitrev':
-        samples = np.reshape(samples,(-1,8))[:,::-1].flatten();
+        samples = np.reshape(samples, (-1, 8))[:, ::-1].flatten();
     samples = samples[num_skip_samples:]
     if num_samples > 0:
       samples = samples[:num_samples]
+    tmp = np.ndarray((1, len(samples)), dtype=np.int8)
+    tmp[0][:] = samples
+    samples = tmp
 
+  elif file_format == '1bit_x2':
+    # Interleaved single bit samples from two receivers
+    s_file = np.memmap(filename, offset=num_skip, dtype=np.uint8, mode='r')
+    n_rx = 2
+    print "Num samples", num_samples
+    if num_samples > 0:
+      print "Trimming file to ", num_samples, (num_samples * n_rx + 7) / 8, "from", len(s_file)
+      s_file = s_file[:(num_samples * n_rx + 7) / 8]
+    bits = np.unpackbits(s_file)
+    print "Unpacked: ", len(bits), len(bits) / n_rx
+    samples = np.empty((n_rx, num_samples), dtype=np.int8)
+    lookup = np.asarray((1, -1), dtype=np.int8)
+    for rx in range(n_rx):
+      samples[rx][:] = lookup[bits[rx:n_rx * (num_samples + 1):n_rx]]
   else:
     raise ValueError("Unknown file type '%s'" % file_format)
 


### PR DESCRIPTION
Added support for loading file with two diferent codes (bands).
Added 1bit_x2 file format, updated tracking loop analysys.

@adel-mamin Can you review and merge the change into your branch? There are a lot of whitespace changes because I use source code auto-formatter (autopep8.py).
